### PR TITLE
[fix] open link to HearThis in external browser

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -32,6 +32,12 @@ function createWindow() {
   }
 
   mainWindow.on('closed', () => (mainWindow = null));
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (url.startsWith('http:') || url.startsWith('https:')) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
+  });
 }
 
 function handleGetFonts() {


### PR DESCRIPTION
I found an issue on my machine because HearThis wasn't installed it showed me an error indicating that, however there was a link to HearThis, but it unfortunately opened the link in Bible Karaoke with no way of getting back to the main application. With this change all external links should be opened in an external browser.