### PR TITLE
Improve locating of required ffmpeg cli utilities

### DIFF
--- a/public/cli/lib/commands/ffmpeg.js
+++ b/public/cli/lib/commands/ffmpeg.js
@@ -176,7 +176,7 @@ function checkAudioInput(done) {
                     ffmpegExe = Options.ffmpegPath;
                 }
                 shell.exec(
-                    `${ffmpegExe} -f concat -safe 0 -i "${fileDir}" -c copy "${Options.audioInput}"`,
+                    `"${ffmpegExe}" -f concat -safe 0 -i "${fileDir}" -c copy "${Options.audioInput}"`,
                     (err) => {
                         done(err);
                     }
@@ -214,7 +214,7 @@ function execute(done, err) {
     }
 
     shell.exec(
-        `${ffmpegExe} -framerate ${Options.framerateIn} -i "${path.join(
+        `"${ffmpegExe}" -framerate ${Options.framerateIn} -i "${path.join(
             Options.images,
             "frame_%06d.png"
         )}" -i "${Options.audioInput}" ${

--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -4,10 +4,37 @@ const shell = require('shelljs');
 
 module.exports = { setupFfmpeg };
 
+/**
+ * locates the "binaries" directory containing the ffmpeg utilities
+ * sets the executable bit on all of the utilities
+ *
+ * returns the path to the binaries directory
+ */
 async function setupFfmpeg() {
-  let dest = path.join(process.cwd(), 'binaries');
+  //example paths to binaries folder:
+  //
+  // Linux AppImage: /tmp/.mount_Bible cusbqB/
+  //        Windows: C:\Users\bob\
+  //   electron-dev: /Users/bob/bible-karaoke/node_modules/electron/dist/
+
+  let executableFilename = process.execPath;
+
+  let executablePath = path.dirname(executableFilename);
+
+  // if in the electron-dev environment, running from node_modules tree
+  // so find the parent to the node_modules directory
+  const NODE_MODULES = "node_modules";
+
+  if (executablePath.includes(NODE_MODULES)) {
+    let node_modules_position = executablePath.indexOf(NODE_MODULES);
+    executablePath = executablePath.substring(0, node_modules_position);
+  }
+
+  let binariesPath = path.join(executablePath, 'binaries');
+
+  console.log( `ffmpeg.js: setupFfmpeg() binaries directory: [${binariesPath}]` );
 
   // Ensure executables are... executable
-  shell.chmod('+X', path.join(dest, '*.*'));
-  return dest;
+  shell.chmod('+X', path.join(binariesPath, (process.platform == 'win32') ? '*.*' : '*' ));
+  return binariesPath;
 }


### PR DESCRIPTION
In certain circumstances, the binary tools ffmpeg and ffprobe
utilities cannot be located.  This results in an error when
interacting with sound files, such as "Error trying to read audio
length". The algorithm for locating the binaries directory has been
made more robust.  Linux AppImages now run properly.

Problem scenarios included running from outside the directory:
`bible-karaoke/dist/linux-unpacked/bible-karaoke

Running from AppImage:
`./'Bible` Karaoke-0.3.3.AppImage'

Directories with a space in the name
`/tmp/Bible` Karaoke/bible-karaoke
