### PR TITLE
Apply natural sorting to chapter lists

### DIFF
--- a/public/hear-this.js
+++ b/public/hear-this.js
@@ -77,7 +77,11 @@ function makeBook(projectName, name) {
   let chapterNames = getDirectories(
     path.join(DEFAULT_DATA_DIR, projectName, name),
   );
-  book.chapters = chapterNames
+
+  let naturalSortChapterNames = chapterNames
+    .sort(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'}).compare);
+
+  book.chapters = naturalSortChapterNames
     .map(chapterName => makeChapter(projectName, name, chapterName))
     .filter(chapter => chapter.audioFiles.length > 0);
   return book;


### PR DESCRIPTION
After reading the directory under a book (the list of chapters), apply a natural sort algorithm.  Using 
[Intl.Collator.prototype.compare](http://ecma-international.org/ecma-402/1.0/#sec-10.3.2).

`1,10,11,2,20`

 sorts out to 

`1,2,10,11,20`
