### PR TITLE
Add support for settings (picking root folders)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10555,6 +10555,14 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.4.tgz",
       "integrity": "sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw=="
     },
+    "mobx-persist": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mobx-persist/-/mobx-persist-0.4.1.tgz",
+      "integrity": "sha512-cPxVuZTY5neesxOV/Z25SF4+/NbC6wfHOe9HT5XoSEkAALNxNE41yDK48peJQ3iK14m0G2ywQRklCXeV3wftnQ==",
+      "requires": {
+        "serializr": "^1.1.11"
+      }
+    },
     "mobx-react": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.2.2.tgz",
@@ -14416,6 +14424,11 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "serializr": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/serializr/-/serializr-1.5.4.tgz",
+      "integrity": "sha512-ImLlkNfNSSv9d7Ah1j/yrPk1FHbRC1zkD7URcgx/8M1eYHGUxGf/Ig/d8ML04ifqN7QesyYKsfLYA4xjAVAR/g=="
     },
     "serve-index": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lodash": "^4.17.19",
     "minimist": "^1.2.5",
     "mobx": "^5.15.4",
+    "mobx-persist": "^0.4.1",
     "mobx-react": "^6.2.2",
     "node-sass": "^4.14.1",
     "progress": "^2.0.3",

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,7 +1,9 @@
 const electron = require('electron');
+const reduce = require('lodash/reduce');
 const fontList = require('font-list');
 const karaoke = require('./karaoke');
-const { getProjectStructure, getSampleVerses } = require('./hear-this');
+const sources = require('./sources')
+const { getSampleVerses } = require('./sources/util')
 
 const { app, ipcMain, shell, Menu } = electron;
 const BrowserWindow = electron.BrowserWindow;
@@ -10,7 +12,6 @@ const path = require('path');
 const isDev = require('electron-is-dev');
 
 let mainWindow;
-let hearThisProjects;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -69,8 +70,11 @@ function handleGetSampleVerses() {
 function handleGetProjects() {
   ipcMain.on('did-start-getprojectstructure', async event => {
     console.log('Getting project structure');
-    hearThisProjects = getProjectStructure();
-    event.sender.send('did-finish-getprojectstructure', hearThisProjects);
+    const projects = reduce(sources, (acc, source) => {
+      acc.push(...source.getProjectStructure())
+      return acc
+    }, [])
+    event.sender.send('did-finish-getprojectstructure', projects);
   });
 }
 

--- a/public/electron.js
+++ b/public/electron.js
@@ -60,8 +60,8 @@ function handleGetFonts() {
 
 function handleGetSampleVerses() {
   ipcMain.on('did-start-getverses', async (event, args) => {
-    const { hearThisFolder } = args;
-    const verses = getSampleVerses(hearThisFolder);
+    const { sourceDirectory } = args;
+    const verses = getSampleVerses(sourceDirectory);
     event.sender.send('did-finish-getverses', verses);
   });
 }

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,5 +1,6 @@
 const electron = require('electron');
-const reduce = require('lodash/reduce');
+const map = require('lodash/map');
+const flatten = require('lodash/flatten');
 const fontList = require('font-list');
 const karaoke = require('./karaoke');
 const sources = require('./sources')
@@ -15,7 +16,7 @@ let mainWindow;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 880,
+    width: 1100,
     height: 970,
     webPreferences: { nodeIntegration: true, webSecurity: false },
   });
@@ -68,12 +69,13 @@ function handleGetSampleVerses() {
 }
 
 function handleGetProjects() {
-  ipcMain.on('did-start-getprojectstructure', async event => {
-    console.log('Getting project structure');
-    const projects = reduce(sources, (acc, source) => {
-      acc.push(...source.getProjectStructure())
-      return acc
-    }, [])
+  ipcMain.on('did-start-getprojectstructure', async (event, rootDirectories) => {
+    console.log('Getting project structure', rootDirectories);
+    const projects = flatten(
+      map(rootDirectories, (directories, projectType) => {
+        return sources[projectType].getProjectStructure(directories)
+      })
+    )
     event.sender.send('did-finish-getprojectstructure', projects);
   });
 }

--- a/public/hear-this.js
+++ b/public/hear-this.js
@@ -112,9 +112,9 @@ function makeChapter(projectName, bookName, name) {
   return chapter;
 }
 
-function getSampleVerses(hearThisFolder) {
+function getSampleVerses(sourceDirectory) {
   try {
-    const info = fs.readFileSync(path.join(hearThisFolder, 'info.xml'), 'utf8');
+    const info = fs.readFileSync(path.join(sourceDirectory, 'info.xml'), 'utf8');
     var jsonInfo = JSON.parse(xml2json.xml2json(info, { compact: true }));
     var verses = jsonInfo.ChapterInfo.Recordings.ScriptLine.slice(0, 4).map( line => {
       // Fix #20 : ignore Chapter Headings

--- a/public/karaoke.js
+++ b/public/karaoke.js
@@ -10,7 +10,7 @@ module.exports = {
 };
 
 async function execute({
-  hearThisFolder,
+  sourceDirectory,
   textLocation,
   background,
   text,
@@ -22,7 +22,7 @@ async function execute({
     let ffmpegFolder = await setupFfmpeg();
     const ffmpegPath = path.join(ffmpegFolder, FFMPEG_EXE);
     await bbkConvert({
-      _: [hearThisFolder],
+      _: [sourceDirectory],
       output,
       ffmpegPath,
       textLocation: textLocation.location,
@@ -53,7 +53,7 @@ async function execute({
 //     };
 //     try {
 //         const executeArgs = {
-//           hearThisFolder: 'C:\\ProgramData\\SIL\\HearThis\\ENT\\Mark\\1',
+//           sourceDirectory: 'C:\\ProgramData\\SIL\\HearThis\\ENT\\Mark\\1',
 //           backgroundFile: 'C:\\DigiServe\\bible-karaoke\\cross-blog_orig.jpg',
 //           backgroundColor: '',
 //           speechBubbleColor: 'white',

--- a/public/sources/hear-this.js
+++ b/public/sources/hear-this.js
@@ -2,40 +2,14 @@ const fs = require('fs');
 const process = require('process');
 const os = require('os');
 const path = require('path');
-const xml2json = require('xml-js');
+const {
+  Project,
+  Book,
+  Chapter,
+  getDirectories
+} = require('./util');
 
-module.exports = {
-  getProjectStructure,
-  getSampleVerses,
-};
-
-const isDirectory = source => fs.lstatSync(source).isDirectory();
-
-const getDirectories = source =>
-  fs.readdirSync(source).filter(name => isDirectory(path.join(source, name)));
-
-class Project {
-  constructor() {
-    this.name = '';
-    this.books = [];
-  }
-}
-
-class Book {
-  constructor() {
-    this.name = '';
-    this.chapters = [];
-  }
-}
-
-class Chapter {
-  constructor() {
-    this.name = '';
-    this.fullPath = '';
-    this.audioFiles = [];
-    this.textXmlFile = '';
-  }
-}
+const PROJECT_TYPE = 'hearThis'
 
 function getDefaultDataDirectory() {
   switch (process.platform) {
@@ -62,7 +36,7 @@ function getProjectStructure() {
 }
 
 function makeProject(name) {
-  let project = new Project();
+  let project = new Project(PROJECT_TYPE);
   project.name = name;
   const bookNames = getDirectories(path.join(DEFAULT_DATA_DIR, name));
   project.books = bookNames
@@ -112,28 +86,7 @@ function makeChapter(projectName, bookName, name) {
   return chapter;
 }
 
-function getSampleVerses(sourceDirectory) {
-  try {
-    const info = fs.readFileSync(path.join(sourceDirectory, 'info.xml'), 'utf8');
-    var jsonInfo = JSON.parse(xml2json.xml2json(info, { compact: true }));
-    var verses = jsonInfo.ChapterInfo.Recordings.ScriptLine.slice(0, 4).map( line => {
-      // Fix #20 : ignore Chapter Headings
-      if (line.HeadingType && line.HeadingType._text == "c") {
-          return;
-      }
-      let text = line.Text._text;
-      if (line.Heading._text === "true") {
-          text = "<strong>"+text+"</strong>";
-      }
-      return text;
-    });
-    // use .filter() to remove any undefined elements
-    verses = verses.filter((v)=>{ return v;});
-    // only return 3
-    if (verses.length > 3) verses.pop();    
-    return verses;
-  } catch (err) {
-    console.error('Failed to get sample verses', err);
-    return 'Failed to get sample verses';
-  }
-}
+module.exports = {
+  PROJECT_TYPE,
+  getProjectStructure,
+};

--- a/public/sources/index.js
+++ b/public/sources/index.js
@@ -1,0 +1,7 @@
+const hearThis = require('./hear-this');
+const scriptureAppBuilder = require('./scripture-app-builder');
+
+module.exports = {
+  [hearThis.PROJECT_TYPE]: hearThis,
+  [scriptureAppBuilder.PROJECT_TYPE]: scriptureAppBuilder
+}

--- a/public/sources/scripture-app-builder.js
+++ b/public/sources/scripture-app-builder.js
@@ -1,0 +1,27 @@
+const {
+  Project,
+  Book,
+  Chapter,
+  getDirectories
+} = require('./util')
+
+const PROJECT_TYPE = 'scriptureAppBuilder'
+
+function getDefaultDataDirectory() {
+  switch (process.platform) {
+    case 'win32':
+      return '%UserProfile%/Documents/App Builder/Scripture Apps/App Projects/';
+    case 'darwin':
+    default:
+      return `${os.homedir()}/App Builder/Scripture Apps/App Projects/`;
+  }
+}
+
+function getProjectStructure() {
+  return []
+}
+
+module.exports = {
+  PROJECT_TYPE,
+  getProjectStructure,
+};

--- a/public/sources/scripture-app-builder.js
+++ b/public/sources/scripture-app-builder.js
@@ -7,17 +7,7 @@ const {
 
 const PROJECT_TYPE = 'scriptureAppBuilder'
 
-function getDefaultDataDirectory() {
-  switch (process.platform) {
-    case 'win32':
-      return '%UserProfile%/Documents/App Builder/Scripture Apps/App Projects/';
-    case 'darwin':
-    default:
-      return `${os.homedir()}/App Builder/Scripture Apps/App Projects/`;
-  }
-}
-
-function getProjectStructure() {
+function getProjectStructure(directories) {
   return []
 }
 

--- a/public/sources/util.js
+++ b/public/sources/util.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const xml2json = require('xml-js');
+
+const isDirectory = source => fs.lstatSync(source).isDirectory();
+
+const getDirectories = source =>
+  fs.readdirSync(source).filter(name => isDirectory(path.join(source, name)));
+
+class Project {
+  constructor(projectType) {
+    this.projectType = projectType
+    this.name = '';
+    this.books = [];
+  }
+}
+
+class Book {
+  constructor() {
+    this.name = '';
+    this.chapters = [];
+  }
+}
+
+class Chapter {
+  constructor() {
+    this.name = '';
+    this.fullPath = '';
+    this.audioFiles = [];
+    this.textXmlFile = '';
+  }
+}
+
+function getSampleVerses(sourceDirectory) {
+  try {
+    const info = fs.readFileSync(path.join(sourceDirectory, 'info.xml'), 'utf8');
+    var jsonInfo = JSON.parse(xml2json.xml2json(info, { compact: true }));
+    var verses = jsonInfo.ChapterInfo.Recordings.ScriptLine.slice(0, 4).map( line => {
+      // Fix #20 : ignore Chapter Headings
+      if (line.HeadingType && line.HeadingType._text == "c") {
+          return;
+      }
+      let text = line.Text._text;
+      if (line.Heading._text === "true") {
+          text = "<strong>"+text+"</strong>";
+      }
+      return text;
+    });
+    // use .filter() to remove any undefined elements
+    verses = verses.filter((v)=>{ return v;});
+    // only return 3
+    if (verses.length > 3) verses.pop();    
+    return verses;
+  } catch (err) {
+    console.error('Failed to get sample verses', err);
+    return 'Failed to get sample verses';
+  }
+}
+
+module.exports = {
+  getSampleVerses,
+  getDirectories,
+  Project,
+  Book,
+  Chapter
+};

--- a/src/App/components/Accordion.js
+++ b/src/App/components/Accordion.js
@@ -13,7 +13,7 @@ import ActionButton from './ActionButton';
 import './Accordion.scss';
 import { trackEvent } from '../analytics';
 
-@inject('store')
+@inject('appState')
 @observer
 class Accordion extends React.PureComponent {
   constructor(props) {
@@ -45,7 +45,7 @@ class Accordion extends React.PureComponent {
   render() {
     const {
       cards,
-      store: { stepStatus },
+      appState: { stepStatus },
     } = this.props;
     const { currentCardIndex } = this.state;
     return (

--- a/src/App/components/FileSelector.js
+++ b/src/App/components/FileSelector.js
@@ -6,6 +6,8 @@ const { dialog } = remote;
 
 const FileSelector = ({
   save = false,
+  buttonText = 'Select',
+  buttonIcon,
   disabled = false,
   file,
   options,
@@ -22,7 +24,7 @@ const FileSelector = ({
   return (
     <div className='file-selector'>
       <div className='file-selector__button'>
-        <Button text='Select' onClick={selectFile} disabled={disabled} />
+        <Button text={buttonText} icon={buttonIcon} onClick={selectFile} disabled={disabled} />
       </div>
       <div className='file-selector__filename'>{file}</div>
     </div>

--- a/src/App/components/Settings.js
+++ b/src/App/components/Settings.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import uniq from 'lodash/uniq';
+import without from 'lodash/without';
+import { H5, Icon, Card, Button, Classes } from '@blueprintjs/core';
+import { useObserver } from 'mobx-react';
+import { useStores } from '../store';
+import FileSelector from './FileSelector';
+import './Settings.scss';
+
+const DirectoriesCard = ({name, directories, onSetDirectories}) => {
+  const addDirectory = (folder) => {
+    onSetDirectories(uniq([...directories, folder]))
+  }
+  
+  const removeDirectory = (folder) => {
+    onSetDirectories(without(directories, folder))
+  }
+
+  return (
+    <Card className="settings__card">
+      <div className="settings__card-title">
+        <H5>{name} Projects Folders</H5>
+        <FileSelector
+          buttonText="Add folder..."
+          buttonIcon="folder-new"
+          options={{
+            title: `Select ${name} folder`,
+            properties: ['openDirectory'],
+          }}
+          onFileSelected={addDirectory}
+        />
+      </div>
+      <ul className={`${Classes.LIST} ${Classes.LIST_UNSTYLED}`}>
+        {directories.map(dir => (
+          <li className="settings__directory" key={dir}>
+            <Icon icon="folder-close" />
+            <span className={`settings__directory-name ${Classes.UI_TEXT} ${Classes.TEXT_OVERFLOW_ELLIPSIS}`} title={dir}>{dir}</span>
+            <Button minimal icon='cross' onClick={() => { removeDirectory(dir) }} />
+          </li>
+        ))}
+      </ul>
+    </Card>
+  )
+}
+
+export default function Settings() {
+  const { settings } = useStores()
+
+  return useObserver(() => (
+    <div className="settings">
+      <DirectoriesCard 
+        name="HearThis" 
+        directories={settings.hearThisRootDirectories} 
+        onSetDirectories={settings.setHearThisRootDirectories} 
+      />
+      <DirectoriesCard 
+        name="Scripture App Builder" 
+        directories={settings.scriptureAppBuilderRootDirectories} 
+        onSetDirectories={settings.setScriptureAppBuilderRootDirectories} 
+      />
+    </div>
+  ))
+}

--- a/src/App/components/Settings.scss
+++ b/src/App/components/Settings.scss
@@ -1,0 +1,28 @@
+.settings {
+  padding: 20px;
+  flex: 1;
+  background: #293742;
+  &__card {
+    margin-bottom: 20px;
+  }
+  .file-selector > * {
+    margin: 0;
+  }
+  &__card-title {
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    h5 {
+      flex: 1;
+      margin-bottom: 0;
+    }
+  }
+  &__directory {
+    display: flex;
+    align-items: center;
+    &-name {
+      padding: 0 10px;
+    }
+  }
+}

--- a/src/App/components/cards/DisplayCard.js
+++ b/src/App/components/cards/DisplayCard.js
@@ -38,14 +38,14 @@ const FONT_SIZES = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20].map(n => ({
   label: `${n}pt`,
 }));
 
-@inject('store')
+@inject('appState')
 @observer
 class DisplayCard extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
       fonts: [],
-      backgroundOption: props.store.background.color ? BG.COLOR : BG.FILE,
+      backgroundOption: props.appState.background.color ? BG.COLOR : BG.FILE,
     };
     ipcRenderer.on('did-finish-getfonts', (event, fonts) => {
       if (Array.isArray(fonts)) {
@@ -63,14 +63,14 @@ class DisplayCard extends React.PureComponent {
   }
 
   onSetTextLocation = evt => {
-    this.props.store.setTextLocation({
+    this.props.appState.setTextLocation({
       location: evt.currentTarget.value
     });
   };
 
   setBackgroundOption = backgroundOption => {
     this.setState({ backgroundOption }, () => {
-      this.props.store.setBackground({
+      this.props.appState.setBackground({
         color: backgroundOption === BG.COLOR ? DEFAULT_BG_COLOR : '',
         file: '',
       });
@@ -78,50 +78,50 @@ class DisplayCard extends React.PureComponent {
   };
 
   onBackgroundColorPickerChange = color => {
-    this.props.store.setBackground({ file: '', color: color.hex });
+    this.props.appState.setBackground({ file: '', color: color.hex });
   };
 
   onBackgroundFileSelected = file => {
-    this.props.store.setBackground({ file, color: '' });
+    this.props.appState.setBackground({ file, color: '' });
   };
 
   onSetFontFamily = evt => {
-    this.props.store.setTextProps({ fontFamily: evt.currentTarget.value });
+    this.props.appState.setTextProps({ fontFamily: evt.currentTarget.value });
   };
 
   onSetFontSize = evt => {
-    this.props.store.setTextProps({ fontSize: evt.currentTarget.value });
+    this.props.appState.setTextProps({ fontSize: evt.currentTarget.value });
   };
 
   onTextColorPickerChange = color => {
-    this.props.store.setTextProps({ color: color.hex });
+    this.props.appState.setTextProps({ color: color.hex });
   };
 
   onHighlightColorPickerChange = color => {
-    this.props.store.setTextProps({ highlightColor: color.hex , highlightRGB: "rgba("+color.rgb.r+","+color.rgb.g+","+color.rgb.b+",1)" });
+    this.props.appState.setTextProps({ highlightColor: color.hex , highlightRGB: "rgba("+color.rgb.r+","+color.rgb.g+","+color.rgb.b+",1)" });
     console.log(this.props);
   };
 
   toggleBold = () => {
-    this.props.store.setTextProps({ bold: !this.props.store.text.bold });
+    this.props.appState.setTextProps({ bold: !this.props.appState.text.bold });
   };
 
   toggleItalic = () => {
-    this.props.store.setTextProps({ italic: !this.props.store.text.italic });
+    this.props.appState.setTextProps({ italic: !this.props.appState.text.italic });
   };
 
   onSpeechBubbleColorPickerChange = color => {
       console.log(color);
-    this.props.store.setSpeechBubbleProps({ color: color.hex, rgba: "rgba("+color.rgb.r+","+color.rgb.g+","+color.rgb.b+",1)" });
+    this.props.appState.setSpeechBubbleProps({ color: color.hex, rgba: "rgba("+color.rgb.r+","+color.rgb.g+","+color.rgb.b+",1)" });
   };
 
   onSetSpeechBubbleOpacity = opacity => {
-    this.props.store.setSpeechBubbleProps({ opacity });
+    this.props.appState.setSpeechBubbleProps({ opacity });
   };
 
   render() {
     const {
-      store: { textLocation, background, text, speechBubble, verses },
+      appState: { textLocation, background, text, speechBubble, verses },
     } = this.props;
     const { backgroundOption, fonts } = this.state;
     const previewProps = {

--- a/src/App/components/cards/OutputCard.js
+++ b/src/App/components/cards/OutputCard.js
@@ -3,12 +3,12 @@ import { inject, observer } from 'mobx-react';
 import FileSelector from '../FileSelector';
 import { fileFilters } from '../../constants';
 
-@inject('store')
+@inject('appState')
 @observer
 class OutputCard extends React.PureComponent {
   render() {
     const {
-      store: { outputFile, setOutputFile, defaultVideoName },
+      appState: { outputFile, setOutputFile, defaultVideoName },
     } = this.props;
     return (
       <div className='card__option'>

--- a/src/App/components/cards/TextAndAudioCard.js
+++ b/src/App/components/cards/TextAndAudioCard.js
@@ -128,16 +128,16 @@ class TextAndAudioCard extends React.PureComponent {
   checkFolder = () => {
     const { selectedProject, selectedBook, selectedChapter } = this.state;
     const {
-      store: { hearThisProjects, setHearThisFolder },
+      store: { hearThisProjects, setSourceDirectory },
     } = this.props;
     if (selectedChapter !== noSelection) {
       const hearThisChapterFolder =
         hearThisProjects[selectedProject].books[selectedBook].chapters[
           selectedChapter
         ].fullPath;
-      setHearThisFolder(hearThisChapterFolder);
+        setSourceDirectory(hearThisChapterFolder);
     } else {
-      setHearThisFolder(undefined);
+      setSourceDirectory(undefined);
     }
   };
 

--- a/src/App/components/cards/TextAndAudioCard.js
+++ b/src/App/components/cards/TextAndAudioCard.js
@@ -30,11 +30,11 @@ class TextAndAudioCard extends React.PureComponent {
         },
       );
     });
-    ipcRenderer.send('did-start-getprojectstructure');
+    ipcRenderer.send('did-start-getprojectstructure', this.props.settings.rootDirectories);
   }
 
   refreshProject = () => {
-    ipcRenderer.send('did-start-getprojectstructure');
+    ipcRenderer.send('did-start-getprojectstructure', this.props.settings.rootDirectories);
   };
 
   selectProject = evt => {

--- a/src/App/components/cards/TextAndAudioCard.js
+++ b/src/App/components/cards/TextAndAudioCard.js
@@ -131,11 +131,11 @@ class TextAndAudioCard extends React.PureComponent {
       store: { projects, setSourceDirectory },
     } = this.props;
     if (selectedChapter !== noSelection) {
-      const hearThisChapterFolder =
+      const chapterFolder =
       projects[selectedProject].books[selectedBook].chapters[
           selectedChapter
         ].fullPath;
-        setSourceDirectory(hearThisChapterFolder);
+        setSourceDirectory(chapterFolder);
     } else {
       setSourceDirectory(undefined);
     }
@@ -168,9 +168,10 @@ class TextAndAudioCard extends React.PureComponent {
         : [];
     if (!projects.length) {
       return (
-        <Callout title='No HearThis projects found' intent={Intent.WARNING}>
-          Bible Karaoke was unable to locate any HearThis projects. Make sure{' '}
-          <a href='https://software.sil.org/hearthis/'>HearThis</a> is installed
+        <Callout title='No HearThis or Scripture App Builder projects found' intent={Intent.WARNING}>
+          Bible Karaoke was unable to locate any HearThis or Scripture App Builder projects. Make sure{' '}
+          <a href='https://software.sil.org/hearthis/'>HearThis</a> and/or 
+          <a href='https://software.sil.org/scriptureappbuilder/'>Scripture App Builder</a> is installed
           and you have at least one project with audio for at least one chapter
           of one book.
         </Callout>

--- a/src/App/components/cards/TextAndAudioCard.js
+++ b/src/App/components/cards/TextAndAudioCard.js
@@ -18,7 +18,7 @@ class TextAndAudioCard extends React.PureComponent {
     };
     ipcRenderer.on('did-finish-getprojectstructure', (event, projects) => {
       console.log('Received project structure', projects);
-      this.props.store.setHearThisProjects(projects);
+      this.props.store.setProjects(projects);
       this.setState(
         {
           selectedProject: noSelection,
@@ -80,8 +80,8 @@ class TextAndAudioCard extends React.PureComponent {
   };
 
   checkSingleProject = () => {
-    const hearThisProjects = this.props.store.hearThisProjects;
-    if (hearThisProjects.length === 1) {
+    const projects = this.props.store.projects;
+    if (projects.length === 1) {
       this.setState(
         {
           selectedProject: 0,
@@ -95,9 +95,9 @@ class TextAndAudioCard extends React.PureComponent {
 
   checkSingleBook = () => {
     const selectedProject = this.state.selectedProject;
-    const hearThisProjects = this.props.store.hearThisProjects;
+    const projects = this.props.store.projects;
     if (selectedProject !== noSelection
-        && hearThisProjects[selectedProject].books.length === 1) {
+        && projects[selectedProject].books.length === 1) {
       this.setState(
         {
           selectedBook: 0,
@@ -111,9 +111,9 @@ class TextAndAudioCard extends React.PureComponent {
 
   checkSingleChapter = () => {
     const { selectedProject, selectedBook } = this.state;
-    const hearThisProjects = this.props.store.hearThisProjects;
+    const projects = this.props.store.projects;
     if (selectedBook !== noSelection &&
-        hearThisProjects[selectedProject].books[selectedBook].chapters.length === 1) {
+      projects[selectedProject].books[selectedBook].chapters.length === 1) {
       this.setState(
         {
           selectedChapter: 0,
@@ -128,11 +128,11 @@ class TextAndAudioCard extends React.PureComponent {
   checkFolder = () => {
     const { selectedProject, selectedBook, selectedChapter } = this.state;
     const {
-      store: { hearThisProjects, setSourceDirectory },
+      store: { projects, setSourceDirectory },
     } = this.props;
     if (selectedChapter !== noSelection) {
       const hearThisChapterFolder =
-        hearThisProjects[selectedProject].books[selectedBook].chapters[
+      projects[selectedProject].books[selectedBook].chapters[
           selectedChapter
         ].fullPath;
         setSourceDirectory(hearThisChapterFolder);
@@ -144,29 +144,29 @@ class TextAndAudioCard extends React.PureComponent {
   render() {
     const { selectedProject, selectedBook, selectedChapter } = this.state;
     const {
-      store: { hearThisProjects },
+      store: { projects },
     } = this.props;
-    const projectOptions = hearThisProjects.map((p, index) => ({
+    const projectOptions = projects.map((p, index) => ({
       value: index,
       label: p.name,
     }));
     const bookOptions =
       selectedProject !== noSelection
-        ? hearThisProjects[selectedProject].books.map((p, index) => ({
+        ? projects[selectedProject].books.map((p, index) => ({
             value: index,
             label: p.name,
           }))
         : [];
     const chapterOptions =
       selectedBook !== noSelection
-        ? hearThisProjects[selectedProject].books[selectedBook].chapters.map(
+        ? projects[selectedProject].books[selectedBook].chapters.map(
             (p, index) => ({
               value: index,
               label: p.name,
             }),
           )
         : [];
-    if (!hearThisProjects.length) {
+    if (!projects.length) {
       return (
         <Callout title='No HearThis projects found' intent={Intent.WARNING}>
           Bible Karaoke was unable to locate any HearThis projects. Make sure{' '}

--- a/src/App/components/cards/TextAndAudioCard.js
+++ b/src/App/components/cards/TextAndAudioCard.js
@@ -6,7 +6,7 @@ const { ipcRenderer } = window.require('electron');
 const noSelection = -1;
 const emptyOption = { value: noSelection, label: 'Select....' };
 
-@inject('store')
+@inject('appState', 'settings')
 @observer
 class TextAndAudioCard extends React.PureComponent {
   constructor(props) {
@@ -18,7 +18,6 @@ class TextAndAudioCard extends React.PureComponent {
     };
     ipcRenderer.on('did-finish-getprojectstructure', (event, projects) => {
       console.log('Received project structure', projects);
-      this.props.store.setProjects(projects);
       this.setState(
         {
           selectedProject: noSelection,
@@ -26,6 +25,7 @@ class TextAndAudioCard extends React.PureComponent {
           selectedChapter: noSelection,
         },
         () => {
+          this.props.appState.setProjects(projects);
           this.checkSingleProject();
         },
       );
@@ -80,7 +80,7 @@ class TextAndAudioCard extends React.PureComponent {
   };
 
   checkSingleProject = () => {
-    const projects = this.props.store.projects;
+    const projects = this.props.appState.projects;
     if (projects.length === 1) {
       this.setState(
         {
@@ -95,7 +95,7 @@ class TextAndAudioCard extends React.PureComponent {
 
   checkSingleBook = () => {
     const selectedProject = this.state.selectedProject;
-    const projects = this.props.store.projects;
+    const projects = this.props.appState.projects;
     if (selectedProject !== noSelection
         && projects[selectedProject].books.length === 1) {
       this.setState(
@@ -111,7 +111,7 @@ class TextAndAudioCard extends React.PureComponent {
 
   checkSingleChapter = () => {
     const { selectedProject, selectedBook } = this.state;
-    const projects = this.props.store.projects;
+    const projects = this.props.appState.projects;
     if (selectedBook !== noSelection &&
       projects[selectedProject].books[selectedBook].chapters.length === 1) {
       this.setState(
@@ -128,7 +128,7 @@ class TextAndAudioCard extends React.PureComponent {
   checkFolder = () => {
     const { selectedProject, selectedBook, selectedChapter } = this.state;
     const {
-      store: { projects, setSourceDirectory },
+      appState: { projects, setSourceDirectory },
     } = this.props;
     if (selectedChapter !== noSelection) {
       const chapterFolder =
@@ -144,7 +144,7 @@ class TextAndAudioCard extends React.PureComponent {
   render() {
     const { selectedProject, selectedBook, selectedChapter } = this.state;
     const {
-      store: { projects },
+      appState: { projects },
     } = this.props;
     const projectOptions = projects.map((p, index) => ({
       value: index,

--- a/src/App/components/cards/TimingCard.js
+++ b/src/App/components/cards/TimingCard.js
@@ -3,12 +3,12 @@ import { inject, observer } from 'mobx-react';
 import FileSelector from '../FileSelector';
 import { fileFilters } from '../../constants';
 
-@inject('store')
+@inject('appState')
 @observer
 class TimingCard extends React.PureComponent {
   render() {
     const {
-      store: { timingFile, setTimingFile },
+      appState: { timingFile, setTimingFile },
     } = this.props;
     return (
       <FileSelector

--- a/src/App/components/cards/index.js
+++ b/src/App/components/cards/index.js
@@ -14,9 +14,9 @@ export {
 
 export const cards = [
   {
-    title: 'HearThis',
+    title: 'Input',
     description:
-      'This first step is where you select the HearThis project, book and chapter.' +
+      'This first step is where you select the HearThis or Scripture App Builder project, book and chapter.' +
       ' This folder should contain the text and audio files that will be used in the video.',
     content: <TextAndAudioCard />,
   },

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -16,7 +16,7 @@ const AppStatus = {
   error: 'error',
 };
 
-@inject('store')
+@inject('appState')
 @observer
 class App extends React.PureComponent {
   constructor(props) {
@@ -52,14 +52,14 @@ class App extends React.PureComponent {
   };
 
   openOutputFolder = () => {
-    const { outputFile } = this.props.store;
+    const { outputFile } = this.props.appState;
     ipcRenderer.send('open-output-folder', outputFile);
     this.reset();
   };
 
   onStart = () => {
     this.setState({ status: AppStatus.processing }, () => {
-      const { sourceDirectory, textLocation, background, text, speechBubble, outputFile } = this.props.store;
+      const { sourceDirectory, textLocation, background, text, speechBubble, outputFile } = this.props.appState;
       const args = {
         sourceDirectory,
         textLocation,
@@ -88,7 +88,7 @@ class App extends React.PureComponent {
 
   renderFooter() {
     const {
-      store: { allValidInputs },
+      appState: { allValidInputs },
     } = this.props;
     const { error, status } = this.state;
     switch(status) {

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { inject, observer } from 'mobx-react';
-import { Intent, H1, H6, Classes, Callout, ProgressBar } from '@blueprintjs/core';
+import { Intent, Tooltip, Position, Drawer, Button, H1, H6, Classes, Callout, ProgressBar } from '@blueprintjs/core';
 import { version } from '../../package.json';
 import Accordion from './components/Accordion';
 import { cards } from './components/cards';
 import ActionButton from './components/ActionButton';
+import Settings from './components/Settings';
 import './index.scss';
 import { trackScreenview, trackEvent, trackError } from './analytics';
 const { ipcRenderer } = window.require('electron');
@@ -22,6 +23,7 @@ class App extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      drawerOpen: false,
       status: AppStatus.configuring,
       progress: undefined,
       error: undefined,
@@ -50,6 +52,14 @@ class App extends React.PureComponent {
       error: undefined,
     });
   };
+
+  showSettings = () => {
+    this.setState({ drawerOpen: true })
+  }
+  
+  hideSettings = () => {
+    this.setState({ drawerOpen: false })
+  }
 
   openOutputFolder = () => {
     const { outputFile } = this.props.appState;
@@ -135,14 +145,38 @@ class App extends React.PureComponent {
   }
 
   render() {
+    const {
+      status,
+      drawerOpen
+    } = this.state;
     return (
       <div className='app bp3-dark'>
         <div className='app__container'>
-          <H1>Bible Karaoke</H1>
+          <div className='app__header'>
+            <H1>Bible Karaoke</H1>
+            <Tooltip className="app__settings-btn" content="Settings" position={Position.TOP}>
+              <Button
+                disabled={status === AppStatus.processing}
+                minimal
+                onClick={this.showSettings}
+                icon='cog'
+              />
+            </Tooltip>
+          </div>
           <div className="app__info">Version {version}</div>
           <Accordion cards={cards} />
           <div className='app__footer'>{this.renderFooter()}</div>
         </div>
+        <Drawer
+          className={Classes.DARK}
+          isOpen={drawerOpen}
+          onClose={this.hideSettings}
+          icon='cog'
+          title="Settings"
+          position={Position.RIGHT}
+        >
+          <Settings />
+        </Drawer>
       </div>
     );
   }

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -59,9 +59,9 @@ class App extends React.PureComponent {
 
   onStart = () => {
     this.setState({ status: AppStatus.processing }, () => {
-      const { hearThisFolder, textLocation, background, text, speechBubble, outputFile } = this.props.store;
+      const { sourceDirectory, textLocation, background, text, speechBubble, outputFile } = this.props.store;
       const args = {
-        hearThisFolder,
+        sourceDirectory,
         textLocation,
         background,
         text,

--- a/src/App/index.scss
+++ b/src/App/index.scss
@@ -9,6 +9,18 @@ body,
 .app {
   height: 100%;
   background-color: #30404d;
+  &__header {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  &__settings-btn {
+    position: absolute;
+    right: 0;
+    top: calc(50% - 15px);
+  }
   &__container {
     max-width: 800px;
     margin: 0 auto;

--- a/src/App/store/AppState.js
+++ b/src/App/store/AppState.js
@@ -12,7 +12,7 @@ const SAMPLE_VERSES = [
   "God called the light Day, and the darkness he called Night. And there was evening and there was morning, the first day.",
 ];
 
-class Store {
+class AppState {
   constructor() {
     ipcRenderer.on('did-finish-getverses', (event, verses) => {
       if (Array.isArray(verses)) {
@@ -171,4 +171,4 @@ class Store {
   }
 }
 
-export default Store;
+export default AppState;

--- a/src/App/store/Settings.js
+++ b/src/App/store/Settings.js
@@ -1,0 +1,61 @@
+import { observable, computed, action } from 'mobx';
+import os from 'os';
+import { persist } from 'mobx-persist';
+const { ipcRenderer } = window.require('electron');
+
+// HACK: These values must match the PROJECT_TYPE values in public/sources/*.js
+const HEAR_THIS_PROJECT_TYPE = 'hearThis'
+const SCRIPTURE_APP_BUILDER_PROJECT_TYPE = 'scriptureAppBuilder'
+
+const getDefaultHearThisDirectory = () => {
+  switch (process.platform) {
+    case 'win32':
+      return 'C:/ProgramData/SIL/HearThis/';
+    case 'darwin':
+    default:
+      return `${os.homedir()}/hearThisProjects/`;
+  }
+}
+
+const getDefaultScriptureAppBuilderDirectory = () => {
+  switch (process.platform) {
+    case 'win32':
+      return '%UserProfile%/Documents/App Builder/Scripture Apps/App Projects/';
+    case 'darwin':
+    default:
+      return `${os.homedir()}/App Builder/Scripture Apps/App Projects/`;
+  }
+}
+
+class Settings {
+
+  @persist('list')
+  @observable
+  hearThisRootDirectories = [ getDefaultHearThisDirectory() ]
+
+  @persist('list')
+  @observable
+  scriptureAppBuilderRootDirectories = [ getDefaultScriptureAppBuilderDirectory() ]
+
+  @computed
+  get rootDirectories() {
+    return {
+      [HEAR_THIS_PROJECT_TYPE]: this.hearThisRootDirectories.slice(),
+      [SCRIPTURE_APP_BUILDER_PROJECT_TYPE]: this.scriptureAppBuilderRootDirectories.slice()
+    }
+  }
+
+  @action.bound
+  setHearThisRootDirectories(directories) {
+    this.hearThisRootDirectories = directories
+    ipcRenderer.send('did-start-getprojectstructure', this.rootDirectories);
+  }
+  
+  @action.bound
+  setScriptureAppBuilderRootDirectories(directories) {
+    this.scriptureAppBuilderRootDirectories = directories
+    ipcRenderer.send('did-start-getprojectstructure', this.rootDirectories);
+  }
+}
+
+export default Settings;

--- a/src/App/store/Store.js
+++ b/src/App/store/Store.js
@@ -1,4 +1,5 @@
 import { observable, computed, action } from 'mobx';
+import { persist } from 'mobx-persist';
 import every from 'lodash/every';
 const { ipcRenderer, remote } = window.require('electron');
 var fs = remote.require('fs');
@@ -20,11 +21,8 @@ class Store {
         console.error('Failed to set verses', verses);
       }
     });
-    this.getSpeechBubbleProps();
-    this.getTextLocation();
-    this.getBackground();
-    this.getTextProps();
   }
+
   @observable
   hearThisFolder = '';
 
@@ -34,14 +32,17 @@ class Store {
   @observable
   timingFile = '';
 
+  @persist('object')
   @observable
   textLocation = {
     location: 'subtitle'
   };
 
+  @persist('object')
   @observable
   background = { file: '', color: '#CCC' };
 
+  @persist('object')
   @observable
   text = {
     fontFamily: 'Arial',
@@ -53,6 +54,7 @@ class Store {
     highlightRGB: 'rgba(255,255,0,1)'
   };
 
+  @persist('object')
   @observable
   speechBubble = {
     color: '#FFF',
@@ -117,23 +119,8 @@ class Store {
   }
 
   @action.bound
-  getTextLocation() {
-    if (localStorage.textLocation) {
-      this.setTextLocation(JSON.parse(localStorage.textLocation));
-    }
-  }
-
-  @action.bound
   setTextLocation(textLocationProps) {
     this.textLocation = {...this.textLocation, ...textLocationProps};
-    this.saveLocalProperties("textLocation", textLocationProps);
-  }
-
-  @action.bound
-  getBackground() {
-    if (localStorage.background) {
-      this.setBackground(JSON.parse(localStorage.background));
-    }
   }
 
   @action.bound
@@ -152,20 +139,11 @@ class Store {
       this.background.imageSrc = '';
       this.background.type = 'color';
     }
-    this.saveLocalProperties("background", background);
-  }
-  
-  @action.bound
-  getTextProps() {
-    if (localStorage.text) {
-      this.setTextProps(JSON.parse(localStorage.text));
-    }
   }
 
   @action.bound
   setTextProps(textProps) {
     this.text = {...this.text, ...textProps};
-    this.saveLocalProperties("text", textProps);
   }
   
   @action.bound
@@ -178,16 +156,8 @@ class Store {
   }
 
   @action.bound
-  getSpeechBubbleProps() {
-    if (localStorage.speechBubble) {
-      this.setSpeechBubbleProps(JSON.parse(localStorage.speechBubble));
-    }
-  }
-
-  @action.bound
   setSpeechBubbleProps(speechBubbleProps) {
     this.speechBubble = {...this.speechBubble, ...speechBubbleProps};
-    this.saveLocalProperties("speechBubble", speechBubbleProps);
   }
   
   @action.bound

--- a/src/App/store/Store.js
+++ b/src/App/store/Store.js
@@ -66,7 +66,7 @@ class Store {
   outputFile = '';
 
   @observable
-  hearThisProjects = [];
+  projects = [];
 
   @computed
   get defaultVideoName() {
@@ -93,8 +93,8 @@ class Store {
   }
 
   @action.bound
-  setHearThisProjects(projects) {
-    this.hearThisProjects = projects;
+  setProjects(projects) {
+    this.projects = projects;
     this.sourceDirectory = '';
   }
 

--- a/src/App/store/Store.js
+++ b/src/App/store/Store.js
@@ -24,7 +24,7 @@ class Store {
   }
 
   @observable
-  hearThisFolder = '';
+  sourceDirectory = '';
 
   @observable
   verses = SAMPLE_VERSES;
@@ -70,11 +70,11 @@ class Store {
 
   @computed
   get defaultVideoName() {
-    if (!this.hearThisFolder) {
+    if (!this.sourceDirectory) {
       return 'bible-karaoke.mp4';
     }
     // Name the video by book and chapter (e.g. 'Mark2.mp4')
-    const dirs = this.hearThisFolder.split(/[/\\]/);
+    const dirs = this.sourceDirectory.split(/[/\\]/);
     let chapter = dirs[dirs.length - 1];
     if (chapter === '0') {
       chapter = 'Intro';
@@ -85,7 +85,7 @@ class Store {
   @computed
   get stepStatus() {
     return [
-      !!this.hearThisFolder,
+      !!this.sourceDirectory,
       // !!this.timingFile,
       (!!this.background.file || !!this.background.color) && this.text.fontFamily,
       !!this.outputFile,
@@ -95,14 +95,14 @@ class Store {
   @action.bound
   setHearThisProjects(projects) {
     this.hearThisProjects = projects;
-    this.hearThisFolder = '';
+    this.sourceDirectory = '';
   }
 
   @action.bound
-  setHearThisFolder(folder) {
-    this.hearThisFolder = folder;
+  setSourceDirectory(folder) {
+    this.sourceDirectory = folder;
     if (folder) {
-      ipcRenderer.send('did-start-getverses', { hearThisFolder: folder });
+      ipcRenderer.send('did-start-getverses', { sourceDirectory: folder });
     } else {
       this.setVerses(SAMPLE_VERSES);
     }

--- a/src/App/store/index.js
+++ b/src/App/store/index.js
@@ -1,1 +1,25 @@
-export { default as Store } from './Store';
+import React from 'react';
+import { create } from 'mobx-persist';
+import { MobXProviderContext } from 'mobx-react'
+import AppState from './AppState';
+import Settings from './Settings';
+
+const hydrate = create()
+
+export function useStores() {
+  return React.useContext(MobXProviderContext)
+}
+
+class Store {
+  constructor() {
+    this.appState = new AppState()
+    this.settings = new Settings()
+  }
+
+  async init() {
+    await hydrate('bk-appState', this.appState)
+    await hydrate('bk-settings', this.settings)
+  }
+}
+
+export default Store

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'mobx-react';
+import { create } from 'mobx-persist';
 import App from './App';
 import { Store } from './App/store';
 import './index.css';
 
 const store = new Store();
+const hydrate = create()
 
-ReactDOM.render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
-  document.getElementById('root'),
-);
+hydrate('bk', store).then (() => {
+  ReactDOM.render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+    document.getElementById('root'),
+  );
+})
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'mobx-react';
-import { create } from 'mobx-persist';
 import App from './App';
-import { Store } from './App/store';
+import Store from './App/store';
 import './index.css';
 
 const store = new Store();
-const hydrate = create()
 
-hydrate('bk', store).then (() => {
+store.init().then (() => {
   ReactDOM.render(
-    <Provider store={store}>
+    <Provider {...store}>
       <App />
     </Provider>,
     document.getElementById('root'),


### PR DESCRIPTION
This PR adds basic support for Settings - current just allows the user to specify the HearThis and Scripture App Builder root directories.

(This is branched off the [`scripture-app-builder-ui`](https://github.com/sillsdev/bible-karaoke/tree/scripture-app-builder-ui) branch so that should be completed and merged before we merge this one).

![Bible Karaoke Settings](https://user-images.githubusercontent.com/2925657/85850221-8f1abd00-b7d6-11ea-801b-72312d4fca2f.gif)
