### PR TITLE
Add 'Reset Client ID' button to Settings

### DIFF
--- a/src/App/analytics.js
+++ b/src/App/analytics.js
@@ -1,51 +1,77 @@
 import GoogleAnalytics from 'electron-ga';
 import { reaction } from 'mobx';
 
+const DEV_TRACK_ID = 'UA-169320344-1';
+const TRACK_ID = 'UA-22170471-17';
 const isDev = require('electron-is-dev');
 
-class Analytics {
-  constructor(settings) {
-    this.ga =  new GoogleAnalytics(settings.analyticsTrackingId);
-    this.isEnabled = !isDev && settings.enableAnalytics;
-    reaction(
-      () => settings.analyticsTrackingId,
-      (analyticsTrackingId) => {
-        this.ga =  new GoogleAnalytics(analyticsTrackingId);
-      }
-    )
-    reaction(
-      () => settings.enableAnalytics,
-      (enableAnalytics) => {
-        this.isEnabled = !isDev && enableAnalytics;
-      }
-    )
+class GA {
+  constructor() {
+    this.ga = new GoogleAnalytics(isDev ? DEV_TRACK_ID : TRACK_ID);
+  }
+  
+  resetClientId () {
+    this.ga.resetClientId();
   }
 
   async trackScreenview (screenName) {
     const params = {cd: screenName};
-    if (this.isEnabled) {
-      await this.ga.send('screenview',params);
-    } else {
-      console.log('Analytics Screenview: ' + JSON.stringify(params));
-    }
-  };
+    await this.ga.send('screenview',params);
+  }
   
   async trackEvent (category, action, label = '', value = 0) {
     const params = {ec: category, ea: action, el: label, ev: value};
-    if (this.isEnabled) {
-      await this.ga.send('event', params);
-    } else {
-      console.log('Analytics Event: ' + JSON.stringify(params));
-    }
+    await this.ga.send('event', params);
   }
   
   async trackError (error, fatal = 1) {
     const params = {exd: error, exf:fatal};
-    if (this.isEnabled) {
-      await this.ga.send('exception', params);
-    } else {
-      console.log('Analytics Error: ' + JSON.stringify(params));
+    await this.ga.send('exception', params);
+  }
+}
+
+class DebugGA {  
+  
+  resetClientId () {
+    console.log('Resetting Google Analytics Client ID');
+  }
+  
+  async trackScreenview (screenName) {
+    const params = {cd: screenName};
+    console.log('Analytics Screenview: ' + JSON.stringify(params));
+  }
+  
+  async trackEvent (category, action, label = '', value = 0) {
+    const params = {ec: category, ea: action, el: label, ev: value};
+    await this.ga.send('event', params);
+  }
+  
+  async trackError (error, fatal = 1) {
+    const params = {exd: error, exf:fatal};
+    console.log('Analytics Error: ' + JSON.stringify(params));
+  }
+}
+
+class Analytics {
+  constructor(settings) {
+    const updateProxy = (enableAnalytics) => {
+      const isEnabled = !isDev && enableAnalytics;
+      this.proxy = isEnabled ? new GA() : new DebugGA();
     }
+    updateProxy(settings.enableAnalytics);
+    reaction(
+      () => settings.enableAnalytics,
+      (enableAnalytics) => {
+        updateProxy(enableAnalytics);
+      }
+    )
+
+    const methods = [ 'resetClientId', 'trackScreenview', 'trackEvent', 'trackError' ];
+    methods.forEach(method => {
+      this[method] = (...args) => {
+        this.proxy[method](...args);
+      }
+    }) 
   }
 }
 

--- a/src/App/components/Settings.js
+++ b/src/App/components/Settings.js
@@ -14,6 +14,7 @@ import {
 } from '../store/Settings';
 import FileSelector from './FileSelector';
 import './Settings.scss';
+import { useAnalytics } from './Analytics';
 
 const descriptionTextClass = classnames(Classes.TEXT_SMALL, Classes.TEXT_MUTED);
 
@@ -70,6 +71,7 @@ const DirectoriesCard = ({name, directories, onSetDirectories, defaultDirectory}
 
 export default function Settings() {
   const { settings } = useStores()
+  const { analytics } = useAnalytics()
   const repoUrl = repository.url.replace(/\.git$/, '')
   return useObserver(() => (
     <Flex
@@ -106,6 +108,13 @@ export default function Settings() {
             settings.setEnableAnalytics(event.currentTarget.checked);
           }}
           label="Enable Google Analytics"
+        />
+        <Button
+          text="Reset tracking ID"
+          mt={2}
+          icon="reset"
+          disabled={!settings.enableAnalytics}
+          onClick={analytics.resetClientId}
         />
       </Card>
       <Text mt={3} className={descriptionTextClass} textAlign="center">

--- a/src/App/store/Settings.js
+++ b/src/App/store/Settings.js
@@ -40,10 +40,6 @@ class Settings {
   @observable
   enableAnalytics = false;
 
-  @persist
-  @observable
-  analyticsTrackingId = 'UA-22170471-17';
-
   @computed({ keepAlive: true })
   get rootDirectories() {
     return {
@@ -65,11 +61,6 @@ class Settings {
   @action.bound
   setEnableAnalytics(enableAnalytics) {
     this.enableAnalytics = enableAnalytics;
-  }
-  
-  @action.bound
-  setAnalyticsTrackingId(analyticsTrackingId) {
-    this.analyticsTrackingId = analyticsTrackingId;
   }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2925657/92200575-74cf2080-eea4-11ea-8490-0db6721f7b0f.png)

This button triggers a call to `googleAnalytics.resetClientId`.  The button is disabled if Google Analytics is disabled.

Closes #83 