### PR TITLE
Add support for changing the text location setting

### DIFF
--- a/src/App/components/Preview.js
+++ b/src/App/components/Preview.js
@@ -4,11 +4,13 @@ import styled from 'styled-components';
 import { Flex, Box } from 'reflexbox';
 import { useObserver } from 'mobx-react';
 import { useStores } from '../store';
+import { TEXT_LOCATION } from '../constants';
 import {
   BackgroundEditor,
   FontEditor,
   SpeechBubbleEditor,
 } from './Editors';
+import TextLocationToggle from './TextLocationToggle';
 
 const PREVIEW_WIDTH = '720px';
 const PREVIEW_HEIGHT = '480px';
@@ -132,10 +134,10 @@ const Preview = () => {
     };
     let file = "file:"+background.file;
     const versesClassName = classnames({
-      subtitle: textLocation.location === 'subtitle'
+      subtitle: textLocation.location === TEXT_LOCATION.subtitle
     });
     const getVerseClassName = (index) => classnames({
-      hide: textLocation.location === "subtitle" && index !== HIGHLIGHT_VERSE_INDEX
+      hide: textLocation.location === TEXT_LOCATION.subtitle && index !== HIGHLIGHT_VERSE_INDEX
     });
 
     return (
@@ -151,6 +153,7 @@ const Preview = () => {
             >
               {index === HIGHLIGHT_VERSE_INDEX && (
                 <React.Fragment>
+                  <TextLocationToggle top="calc(50% - 15px)" right="-35px" />
                   <FontEditor mr={2} top="-8px" right="24px" />
                   <SpeechBubbleEditor top="-8px" right="4px" />
                   <SpeechBubbleBackground style={styles.speechBubble} />

--- a/src/App/components/TextLocationToggle.js
+++ b/src/App/components/TextLocationToggle.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useObserver } from 'mobx-react';
+import styled from 'styled-components';
+import { position } from 'styled-system';
+import { Tooltip } from '@blueprintjs/core';
+import { Box } from 'reflexbox';
+import { Button } from '../blueprint';
+import { useStores } from '../store';
+import { TEXT_LOCATION } from '../constants';
+
+const Wrapper = styled(Box) `
+  ${position}
+  position: absolute;
+  line-height: 1;
+  .bp3-popover-target {
+    display: block;
+  }
+`
+
+export default function TextLocationToggle(props) {
+  const { appState } = useStores();
+  const toggleTextLocation = React.useCallback(() => {
+    appState.setTextLocation({
+      location: appState.textLocation.location === TEXT_LOCATION.subtitle
+        ? TEXT_LOCATION.center
+        : TEXT_LOCATION.subtitle
+    });
+  }, [ appState ]);
+  return useObserver(() => {
+    const isSubtitle = appState.textLocation.location === TEXT_LOCATION.subtitle;
+    return (
+      <Wrapper {...props}>
+        <Tooltip content={isSubtitle ? "Switch to centered mode" : "Switch to subtitle mode"}>
+          <Button minimal icon={isSubtitle ? 'arrow-up' : 'arrow-down'} onClick={toggleTextLocation} />
+        </Tooltip>
+      </Wrapper>
+    );
+  })
+}

--- a/src/App/constants.js
+++ b/src/App/constants.js
@@ -5,6 +5,11 @@ export const PROJECT_TYPE = {
   scriptureAppBuilder: 'scriptureAppBuilder'
 };
 
+export const TEXT_LOCATION = {
+  subtitle: 'subtitle',
+  center: 'center',
+};
+
 const allFiles = {
   name: 'All files',
   extensions: ['*'],

--- a/src/App/store/AppState.js
+++ b/src/App/store/AppState.js
@@ -7,6 +7,7 @@ import sortBy from 'lodash/sortBy';
 import filter from 'lodash/filter';
 import values from 'lodash/values';
 import reduce from 'lodash/reduce';
+import { TEXT_LOCATION } from '../constants';
 
 const { ipcRenderer, remote } = window.require('electron');
 var fs = remote.require('fs');
@@ -245,7 +246,7 @@ class AppState {
   @persist('object')
   @observable
   textLocation = {
-    location: 'subtitle'
+    location: TEXT_LOCATION.subtitle
   };
 
   @persist('object')


### PR DESCRIPTION
Can be either `subtitle` or `center`.

This setting is already passed to the CLI tool.

![TextLocation](https://user-images.githubusercontent.com/2925657/92209635-8b32a780-eeb7-11ea-84ff-a2680030df91.gif)
